### PR TITLE
hotfix: node_modules installation

### DIFF
--- a/services/nest/Dockerfile
+++ b/services/nest/Dockerfile
@@ -2,11 +2,15 @@ FROM	node:latest
 
 WORKDIR /usr/app
 
+COPY    ./init_nest.sh /usr/app/
+
 RUN		apt-get update \
 		&& apt-get install -y dumb-init \
 		&& npm install -g npm \
-		&& npm install -g @nestjs/cli
+		&& npm install -g @nestjs/cli \
+        && chmod 777 init_nest.sh
+
 
 ENTRYPOINT	["/usr/bin/dumb-init", "--"]
 
-CMD		["npm", "--prefix", "srcs", "run", "start:dev"]
+CMD		["sh", "init_nest.sh"]

--- a/services/nest/init_nest.sh
+++ b/services/nest/init_nest.sh
@@ -1,0 +1,2 @@
+npm install --prefix srcs
+npm run --prefix srcs start:dev


### PR DESCRIPTION

## 요약
- `npm run` 시점에 모듈이 설치되지 않아서 서버가 켜지지 않는 오류 수정

<br><br>

## 작업 내용
- nest 컨테이너가 생성되는 시점에 명시적으로 노드 모듈들을 설치하도록 스크립트를 추가했습니다.

<br><br>

## 참고 사항
- 본래 Dockerfile 레이어에 `npm install`을 쌓으려고 했는데, 볼륨 마운트 시점 관련한 문제가 있어서 스크립트를 따로 분리하여 처리했습니다.

<br><br>

## 관련 이슈
- X

<br><br>
